### PR TITLE
added spaces where missing

### DIFF
--- a/scripts/03_if and test.md
+++ b/scripts/03_if and test.md
@@ -75,7 +75,7 @@ anna@HP-Printer:~$ test $a = $b ; echo $?
 ```
 * test if `hello` is *equale* to `a`:
 ```
-anna@HP-Printer:~$ test "hello"=$a; echo $?
+anna@HP-Printer:~$ test "hello" = $a; echo $?
 0
 ```
 * test if `d` contains *zero chars*:


### PR DESCRIPTION
Changed:
test "hello"=$a; echo $?
to
test "hello" = $a; echo $?